### PR TITLE
OUT2-1664 update unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,8 +36,13 @@ http {
         add_header Content-Security-Policy "default-src *; font-src 'self' data: fonts.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'; img-src * data: 'unsafe-inline'; connect-src * 'unsafe-inline'; frame-src *; object-src 'none'; base-uri 'self'; frame-ancestors https://treatmentsolutions.com/ https://*.treatmentsolutions.com/;";
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # proxy treatmentsolutions.com/wp-content/uploads/ -> s3 bucket
@@ -47,7 +52,7 @@ http {
         }
 
         # Media: images, icons, video, audio, HTC, 4 hours
-        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc|woff|woff2)$ {
+        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|svg|svgz|mp4|ogg|ogv|webm|webp|htc|woff|woff2)$ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
             root /var/app/current;
         }


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/OUT2-1664

Description:
OUT2-1664 update unserved file types

Example Links:
https://staging.treatmentsolutions.com/test.bak
https://staging.treatmentsolutions.com/test.zip
https://staging.treatmentsolutions.com/test.tar
https://staging.treatmentsolutions.com/test.gz
https://staging.treatmentsolutions.com/test.sql
https://staging.treatmentsolutions.com/test.php
https://staging.treatmentsolutions.com/test.env
https://staging.treatmentsolutions.com/test.aspx
https://staging.treatmentsolutions.com/test.env.aspx
https://staging.treatmentsolutions.com/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.treatmentsolutions.com/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/treatmentsolutions-com-nginx/assets/86256771/ebcd392e-ae50-4c58-a695-6afe30e58fa9)
