### PR TITLE
AAC2 7095 Move CL s3 bucket to proxy

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -75,7 +75,7 @@ http {
         # proxy /aac-common-bucket/ -> common bucket
         location ^~/aac-common-bucket/ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
-            proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common$request_uri;
+            proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common/;
         }
 
         client_header_timeout 60;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -75,7 +75,7 @@ http {
         # proxy /aac-common-bucket/ -> common bucket
         location ^~/aac-common-bucket/ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
-            proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common/;
+            proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common$request_uri;
         }
 
         client_header_timeout 60;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -75,6 +75,10 @@ http {
         # proxy /aac-common-bucket/ -> common bucket
         location ^~/aac-common-bucket/ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
+
+            # Allow periods in the path
+            rewrite ^/my-common-bucket/(.*)$ /$1 break;
+
             proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common/;
         }
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -72,6 +72,12 @@ http {
             rewrite ^(.*)$ https://$host$1/ permanent;
         }
 
+        # proxy /aac-common-bucket/ -> common bucket
+        location ^~/aac-common-bucket/ {
+            add_header Cache-Control "public, max-age=14400, must-revalidate";
+            proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common/;
+        }
+
         client_header_timeout 60;
         client_body_timeout   60;
         keepalive_timeout     60;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -77,7 +77,7 @@ http {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
 
             # Allow periods in the path
-            rewrite ^/my-common-bucket/(.*)$ /$1 break;
+            rewrite ^/aac-common-bucket/(.*)$ /$1 break;
 
             proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common/;
         }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -75,10 +75,6 @@ http {
         # proxy /aac-common-bucket/ -> common bucket
         location ^~/aac-common-bucket/ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
-
-            # Allow periods in the path
-            rewrite ^/aac-common-bucket/(.*)$ /$1 break;
-
             proxy_pass https://aac-common.s3.us-west-2.amazonaws.com/common/;
         }
 


### PR DESCRIPTION
## [AAC2-7095](https://recoverybrands.atlassian.net/browse/AAC2-7095)

#### Brief Description
Add proxy for common bucket

#### Example Link

#### Screenshot

#### Steps Needed to Reproduce Locally


[AAC2-7095]: https://recoverybrands.atlassian.net/browse/AAC2-7095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ