### PR TITLE
add block for no hostname

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -42,7 +42,7 @@ http {
     }
 
     server {
-        listen        80 default_server;
+        listen 80;
         access_log    /var/log/nginx/access.log main;
 
         server_name treatmentsolutions.com staging.treatmentsolutions.com;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -24,6 +24,23 @@ http {
         default     "upgrade";
     }
 
+    # Catch all requests with no server_name
+    # Stop crawlers direct access to servers
+    server {
+        listen 80 default_server;
+        server_name _;
+
+        # Health check location
+        location = /health-check {
+            return 200 OK;
+        }
+
+        # Catch-all for other requests
+        location / {
+            return 444;
+        }
+    }
+
     server {
         listen        80 default_server;
         access_log    /var/log/nginx/access.log main;


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/CP2-1189

- disallow direct access to server ip without hostname
- I guess if you're not on the vpn or whitelisted in CF this request would timeout, but this is an extra layer of caution. did this because was seeing some requests in the error logs going straight to server IP

ex. http://34.212.83.3/treatment/detox-programs/ → 444 (no access for staging IP)
http://44.242.209.49/treatment/detox-programs/ → 200 (prod IP)

* Requires changes to target group health check url in aws before launch https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#TargetGroup:targetGroupArn=arn:aws:elasticloadbalancing:us-west-2:180767807198:targetgroup/awseb-AWSEB-BIP717QI67A8/7c1d4ab7a3e6e6cc